### PR TITLE
fixed logical mistake in giving access rights to creating etc

### DIFF
--- a/src/posts/views.py
+++ b/src/posts/views.py
@@ -24,7 +24,7 @@ from .models import Post
 
 
 def post_create(request):
-	if not request.user.is_staff or not request.user.is_superuser:
+	if not request.user.is_staff and not request.user.is_superuser:
 		raise Http404
 		
 	form = PostForm(request.POST or None, request.FILES or None)
@@ -43,7 +43,7 @@ def post_create(request):
 def post_detail(request, slug=None):
 	instance = get_object_or_404(Post, slug=slug)
 	if instance.publish > timezone.now().date() or instance.draft:
-		if not request.user.is_staff or not request.user.is_superuser:
+		if not request.user.is_staff and not request.user.is_superuser:
 			raise Http404
 	share_string = quote_plus(instance.content)
 
@@ -129,7 +129,7 @@ def post_list(request):
 
 
 def post_update(request, slug=None):
-	if not request.user.is_staff or not request.user.is_superuser:
+	if not request.user.is_staff and not request.user.is_superuser:
 		raise Http404
 	instance = get_object_or_404(Post, slug=slug)
 	form = PostForm(request.POST or None, request.FILES or None, instance=instance)
@@ -149,7 +149,7 @@ def post_update(request, slug=None):
 
 
 def post_delete(request, slug=None):
-	if not request.user.is_staff or not request.user.is_superuser:
+	if not request.user.is_staff and not request.user.is_superuser:
 		raise Http404
 	instance = get_object_or_404(Post, slug=slug)
 	instance.delete()


### PR DESCRIPTION
in previous version:

> if not request.user.is_staff or not request.user.is_superuser:
>       raise Http404 

one could get access only if he is an admin. if he is a staff then this part comes to live: 
`if not request.user.is_superuser: raise 404`
Coz he isn't admin, then 404
